### PR TITLE
use `encodeURIComponent` for encoding param

### DIFF
--- a/lib/url-assembler-factory.js
+++ b/lib/url-assembler-factory.js
@@ -83,8 +83,8 @@ module.exports = function (request) {
     if (typeof key === 'object') {
       return _multiParam(this, key, (value === true));
     }
-    key = encodeURI(key);
-    value = encodeURI(value);
+    key = encodeURIComponent(key);
+    value = encodeURIComponent(value);
     var chainable = this._chain();
     var previous = this.pathname;
     var symbol = ':' + key;

--- a/test/110-instance-with-baseurl.js
+++ b/test/110-instance-with-baseurl.js
@@ -75,6 +75,17 @@ describe('an instance with a baseUrl', function () {
       );
     });
 
+    it('should encode them in the final URL (with param)', function() {
+      myUrl = UrlAssembler('http://example.com')
+          .segment('/search/:p')
+          .param({
+            'p': "-_.!~*'() /;,?:@&=+$_abc_日本語"
+          });
+      expect(myUrl.toString()).to.equal(
+          'http://example.com'
+          + "/search/-_.!~*'()%20%2F%3B%2C%3F%3A%40%26%3D%2B%24_abc_%E6%97%A5%E6%9C%AC%E8%AA%9E"
+      );
+    });
   })
 
 });


### PR DESCRIPTION
Before

```js
const url = UrlAssembler('http://example.com')
        .segment('/search/:p')
        .param({
          'p': "key/value"
        }).toString();
console.log(url); // http://example.com/search/key/value
```

After

```js
const url = UrlAssembler('http://example.com')
        .segment('/search/:p')
        .param({
          'p': "key/value"
        }).toString();
console.log(url); // http://example.com/search/key%2Fvalue
```

Simply use [encodeURIComponent()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent "encodeURIComponent()") instead of [encodeURI()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI "encodeURI()") for encoding `:param`.